### PR TITLE
CopyOnWrite CritBit64

### DIFF
--- a/CritBit/src/org/zoodb/index/critbit/CritBit64COW.java
+++ b/CritBit/src/org/zoodb/index/critbit/CritBit64COW.java
@@ -13,7 +13,7 @@ import java.util.concurrent.locks.ReentrantLock;
 public class CritBit64COW<V> implements Iterable<V> {
 
     private final int DEPTH = 64;
-    private Lock writeLock = new ReentrantLock();
+    private final Lock writeLock = new ReentrantLock();
 
     private AtomicInfo<V> info = new AtomicInfo<>();
 

--- a/CritBit/src/org/zoodb/index/critbit/CritBit64COW.java
+++ b/CritBit/src/org/zoodb/index/critbit/CritBit64COW.java
@@ -8,21 +8,14 @@ package org.zoodb.index.critbit;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class CritBit64COW<V> implements Iterable<V> {
 
     private final int DEPTH = 64;
     private Lock writeLock = new ReentrantLock();
 
-    private Node<V> root;
-    //the following contains either the actual key or the prefix for the sub-node
-    private long rootKey;
-    private V rootVal;
-
-    private int size;
+    private AtomicInfo<V> info = new AtomicInfo<>();
 
     private static class Node<V> {
         //TODO replace posDiff with posMask
@@ -57,6 +50,23 @@ public class CritBit64COW<V> implements Iterable<V> {
         }
     }
 
+    private static class AtomicInfo<V> {
+        private Node<V> root;
+        //the following contains either the actual key or the prefix for the sub-node
+        private long rootKey;
+        private V rootVal;
+        private int size;
+
+        public AtomicInfo<V> copy() {
+            AtomicInfo<V> c = new AtomicInfo<>();
+            c.root = this.root;
+            c.rootKey = this.rootKey;
+            c.rootVal = this.rootVal;
+            c.size = this.size;
+            return c;
+        }
+    }
+
     private CritBit64COW() {
         //private
     }
@@ -71,10 +81,7 @@ public class CritBit64COW<V> implements Iterable<V> {
 
     public CritBit64COW<V> copy() {
         CritBit64COW<V> critBitCopy = create();
-        critBitCopy.root = this.root;
-        critBitCopy.rootKey = this.rootKey;
-        critBitCopy.rootVal = this.rootVal;
-        critBitCopy.size = size();
+        critBitCopy.info = this.info.copy();
         return critBitCopy;
     }
 
@@ -94,113 +101,120 @@ public class CritBit64COW<V> implements Iterable<V> {
     }
 
     private V doPut(long key, V val) {
-        if (size == 0) {
-            rootKey = key;
-            rootVal = val;
-            size++;
-            return null;
-        }
-        if (size == 1) {
-            Node<V> n2 = createNode(key, val, rootKey, rootVal);
-            if (n2 == null) {
-                V prev = rootVal;
-                rootVal = val;
-                return prev;
+        AtomicInfo<V> currentInfo = this.info;
+        AtomicInfo<V> newInfo = this.info.copy();
+        try {
+            int size = currentInfo.size;
+            if (size == 0) {
+                newInfo.rootKey = key;
+                newInfo.rootVal = val;
+                newInfo.size++;
+                return null;
             }
-            root = n2;
-            rootKey = extractPrefix(key, n2.posDiff-1);
-            rootVal = null;
-            size++;
-            return null;
-        }
-        Node<V> n = root;
-        int parentPosDiff = -1;
-        long prefix = rootKey;
-        Node<V> parent = null;
-        boolean isCurrentChildLo = false;
-        while (true) {
-            //perform copy on write
-            n = new Node<V>(n);
-            if (parent != null) {
-                if (isCurrentChildLo) {
-                    parent.lo = n;
-                } else {
-                    parent.hi = n;
+            if (size == 1) {
+                Node<V> n2 = createNode(key, val, info.rootKey, info.rootVal);
+                if (n2 == null) {
+                    V prev = currentInfo.rootVal;
+                    newInfo.rootVal = val;
+                    return prev;
                 }
-            } else {
-                root = n;
+                newInfo.root = n2;
+                newInfo.rootKey = extractPrefix(key, n2.posDiff - 1);
+                newInfo.rootVal = null;
+                newInfo.size++;
+                return null;
             }
-
-            //insertion
-            if (parentPosDiff+1 != n.posDiff) {
-                //split in prefix?
-                int posDiff = compare(key, prefix);
-                if (posDiff < n.posDiff && posDiff != -1) {
-                    Node<V> newSub;
-                    long subPrefix = extractPrefix(prefix, posDiff-1);
-                    if (BitTools.getBit(key, posDiff)) {
-                        newSub = new Node<V>(prefix, null, key, val, posDiff);
-                        newSub.lo = n;
+            Node<V> n = newInfo.root;
+            int parentPosDiff = -1;
+            long prefix = newInfo.rootKey;
+            Node<V> parent = null;
+            boolean isCurrentChildLo = false;
+            while (true) {
+                //perform copy on write
+                n = new Node<V>(n);
+                if (parent != null) {
+                    if (isCurrentChildLo) {
+                        parent.lo = n;
                     } else {
-                        newSub = new Node<V>(key, val, prefix, null, posDiff);
-                        newSub.hi = n;
+                        parent.hi = n;
                     }
-                    if (parent == null) {
-                        rootKey = subPrefix;
-                        root = newSub;
-                    } else if (isCurrentChildLo) {
-                        parent.loPost = subPrefix;
-                        parent.lo = newSub;
-                    } else {
-                        parent.hiPost = subPrefix;
-                        parent.hi = newSub;
-                    }
-                    size++;
-                    return null;
+                } else {
+                    newInfo.root = n;
                 }
-            }
 
-            //prefix matches, so now we check sub-nodes and postfixes
-            if (BitTools.getBit(key, n.posDiff)) {
-                if (n.hi != null) {
-                    prefix = n.hiPost;
-                    parent = n;
-                    n = n.hi;
-                    isCurrentChildLo = false;
-                } else {
-                    Node<V> n2 = createNode(key, val, n.hiPost, n.hiVal);
-                    if (n2 == null) {
-                        V prev = n.hiVal;
-                        n.hiVal = val;
-                        return prev;
+                //insertion
+                if (parentPosDiff + 1 != n.posDiff) {
+                    //split in prefix?
+                    int posDiff = compare(key, prefix);
+                    if (posDiff < n.posDiff && posDiff != -1) {
+                        Node<V> newSub;
+                        long subPrefix = extractPrefix(prefix, posDiff - 1);
+                        if (BitTools.getBit(key, posDiff)) {
+                            newSub = new Node<V>(prefix, null, key, val, posDiff);
+                            newSub.lo = n;
+                        } else {
+                            newSub = new Node<V>(key, val, prefix, null, posDiff);
+                            newSub.hi = n;
+                        }
+                        if (parent == null) {
+                            newInfo.rootKey = subPrefix;
+                            newInfo.root = newSub;
+                        } else if (isCurrentChildLo) {
+                            parent.loPost = subPrefix;
+                            parent.lo = newSub;
+                        } else {
+                            parent.hiPost = subPrefix;
+                            parent.hi = newSub;
+                        }
+                        newInfo.size++;
+                        return null;
                     }
-                    n.hi = n2;
-                    n.hiPost = extractPrefix(key, n2.posDiff-1);
-                    n.hiVal = null;
-                    size++;
-                    return null;
                 }
-            } else {
-                if (n.lo != null) {
-                    prefix = n.loPost;
-                    parent = n;
-                    n = n.lo;
-                    isCurrentChildLo = true;
-                } else {
-                    Node<V> n2 = createNode(key, val, n.loPost, n.loVal);
-                    if (n2 == null) {
-                        V prev = n.loVal;
-                        n.loVal = val;
-                        return prev;
+
+                //prefix matches, so now we check sub-nodes and postfixes
+                if (BitTools.getBit(key, n.posDiff)) {
+                    if (n.hi != null) {
+                        prefix = n.hiPost;
+                        parent = n;
+                        n = n.hi;
+                        isCurrentChildLo = false;
+                    } else {
+                        Node<V> n2 = createNode(key, val, n.hiPost, n.hiVal);
+                        if (n2 == null) {
+                            V prev = n.hiVal;
+                            n.hiVal = val;
+                            return prev;
+                        }
+                        n.hi = n2;
+                        n.hiPost = extractPrefix(key, n2.posDiff - 1);
+                        n.hiVal = null;
+                        newInfo.size++;
+                        return null;
                     }
-                    n.lo = n2;
-                    n.loPost = extractPrefix(key, n2.posDiff-1);
-                    n.loVal = null;
-                    size++;
-                    return null;
+                } else {
+                    if (n.lo != null) {
+                        prefix = n.loPost;
+                        parent = n;
+                        n = n.lo;
+                        isCurrentChildLo = true;
+                    } else {
+                        Node<V> n2 = createNode(key, val, n.loPost, n.loVal);
+                        if (n2 == null) {
+                            V prev = n.loVal;
+                            n.loVal = val;
+                            return prev;
+                        }
+                        n.lo = n2;
+                        n.loPost = extractPrefix(key, n2.posDiff - 1);
+                        n.loVal = null;
+                        newInfo.size++;
+                        return null;
+                    }
                 }
+                parentPosDiff = n.posDiff;
             }
-            parentPosDiff = n.posDiff;
+        } finally {
+            this.info = newInfo;
         }
     }
 
@@ -210,15 +224,16 @@ public class CritBit64COW<V> implements Iterable<V> {
 
     @Override
     public String toString() {
-        if (size == 0) {
+        AtomicInfo<V> info = this.info;
+        if (info.size == 0) {
             return "- -";
         }
-        if (root == null) {
-            return "-" + BitTools.toBinary(rootKey, 64) + " v=" + rootVal;
+        if (info.root == null) {
+            return "-" + BitTools.toBinary(info.rootKey, 64) + " v=" + info.rootVal;
         }
-        Node<V> n = root;
+        Node<V> n = info.root;
         StringBuilder s = new StringBuilder();
-        printNode(n, s, "", 0, rootKey);
+        printNode(n, s, "", 0, info.rootKey);
         return s.toString();
     }
 
@@ -243,14 +258,15 @@ public class CritBit64COW<V> implements Iterable<V> {
     }
 
     public boolean checkTree() {
-        if (root == null) {
-            if (size > 1) {
-                System.err.println("root node = null AND size = " + size);
+        AtomicInfo<V> info = this.info;
+        if (info.root == null) {
+            if (info.size > 1) {
+                System.err.println("root node = null AND size = " + info.size);
                 return false;
             }
             return true;
         }
-        return checkNode(root, 0, rootKey);
+        return checkNode(info.root, 0, info.rootKey);
     }
 
     private boolean checkNode(Node<V> n, int firstBitOfNode, long prefix) {
@@ -330,7 +346,7 @@ public class CritBit64COW<V> implements Iterable<V> {
      * @return the number of keys in the tree
      */
     public int size() {
-        return size;
+        return info.size;
     }
 
     /**
@@ -339,14 +355,16 @@ public class CritBit64COW<V> implements Iterable<V> {
      * @return {@code true} if the key exists otherwise {@code false}
      */
     public boolean contains(long key) {
+        AtomicInfo<V> info = this.info;
+        int size = info.size;
         if (size == 0) {
             return false;
         }
         if (size == 1) {
-            return key == rootKey;
+            return key == info.rootKey;
         }
-        Node<V> n = root;
-        long prefix = rootKey;
+        Node<V> n = info.root;
+        long prefix = info.rootKey;
         while (doesPrefixMatch(n.posDiff, key, prefix)) {
             //prefix matches, so now we check sub-nodes and postfixes
             if (BitTools.getBit(key, n.posDiff)) {
@@ -374,14 +392,15 @@ public class CritBit64COW<V> implements Iterable<V> {
      * @return the values associated with {@code key} or {@code null} if the key does not exist.
      */
     public V get(long key) {
-        if (size == 0) {
+        AtomicInfo<V> info = this.info;
+        if (info.size == 0) {
             return null;
         }
-        if (size == 1) {
-            return (key == rootKey) ? rootVal : null;
+        if (info.size == 1) {
+            return (key == info.rootKey) ? info.rootVal : null;
         }
-        Node<V> n = root;
-        long prefix = rootKey;
+        Node<V> n = info.root;
+        long prefix = info.rootKey;
         while (doesPrefixMatch(n.posDiff, key, prefix)) {
             //prefix matches, so now we check sub-nodes and postfixes
             if (BitTools.getBit(key, n.posDiff)) {
@@ -422,82 +441,89 @@ public class CritBit64COW<V> implements Iterable<V> {
     }
 
     private V doRemove(long key) {
-        if (size == 0) {
-            return null;
-        }
-        if (size == 1) {
-            if (key == rootKey) {
-                size--;
-                rootKey = 0;
-                V prev = rootVal;
-                rootVal = null;
-                return prev;
-            }
-            return null;
-        }
-        Node<V> n = root;
-        Node<V> parent = null;
-        boolean isParentHigh = false;
-        long prefix = rootKey;
-        while (doesPrefixMatch(n.posDiff, key, prefix)) {
-            //perform copy on write
-            n = new Node<V>(n);
-            if (parent != null) {
-                if (!isParentHigh) {
-                    parent.lo = n;
-                } else {
-                    parent.hi = n;
-                }
-            } else {
-                root = n;
-            }
+        AtomicInfo<V> info = this.info;
+        AtomicInfo<V> newInfo = info.copy();
 
-            //prefix matches, so now we check sub-nodes and postfixes
-            if (BitTools.getBit(key, n.posDiff)) {
-                if (n.hi != null) {
-                    isParentHigh = true;
-                    prefix = n.hiPost;
-                    parent = n;
-                    n = n.hi;
-                    continue;
-                } else {
-                    if (key != n.hiPost) {
-                        return null;
-                    }
-                    //match! --> delete node
-                    //replace data in parent node
-                    updateParentAfterRemove(parent, n.loPost, n.loVal, n.lo, isParentHigh);
-                    return n.hiVal;
+        try {
+            if (info.size == 0) {
+                return null;
+            }
+            if (info.size == 1) {
+                if (key == info.rootKey) {
+                    newInfo.size--;
+                    newInfo.rootKey = 0;
+                    V prev = info.rootVal;
+                    info.rootVal = null;
+                    return prev;
                 }
-            } else {
-                if (n.lo != null) {
-                    isParentHigh = false;
-                    prefix = n.loPost;
-                    parent = n;
-                    n = n.lo;
-                    continue;
-                } else {
-                    if (key != n.loPost) {
-                        return null;
+                return null;
+            }
+            Node<V> n = info.root;
+            Node<V> parent = null;
+            boolean isParentHigh = false;
+            long prefix = info.rootKey;
+            while (doesPrefixMatch(n.posDiff, key, prefix)) {
+                //perform copy on write
+                n = new Node<V>(n);
+                if (parent != null) {
+                    if (!isParentHigh) {
+                        parent.lo = n;
+                    } else {
+                        parent.hi = n;
                     }
-                    //match! --> delete node
-                    //replace data in parent node
-                    //for new prefixes...
-                    updateParentAfterRemove(parent, n.hiPost, n.hiVal, n.hi, isParentHigh);
-                    return n.loVal;
+                } else {
+                    newInfo.root = n;
+                }
+
+                //prefix matches, so now we check sub-nodes and postfixes
+                if (BitTools.getBit(key, n.posDiff)) {
+                    if (n.hi != null) {
+                        isParentHigh = true;
+                        prefix = n.hiPost;
+                        parent = n;
+                        n = n.hi;
+                        continue;
+                    } else {
+                        if (key != n.hiPost) {
+                            return null;
+                        }
+                        //match! --> delete node
+                        //replace data in parent node
+                        updateParentAfterRemove(newInfo, parent, n.loPost, n.loVal, n.lo, isParentHigh);
+                        return n.hiVal;
+                    }
+                } else {
+                    if (n.lo != null) {
+                        isParentHigh = false;
+                        prefix = n.loPost;
+                        parent = n;
+                        n = n.lo;
+                        continue;
+                    } else {
+                        if (key != n.loPost) {
+                            return null;
+                        }
+                        //match! --> delete node
+                        //replace data in parent node
+                        //for new prefixes...
+                        updateParentAfterRemove(newInfo, parent, n.hiPost, n.hiVal, n.hi, isParentHigh);
+                        return n.loVal;
+                    }
                 }
             }
+        } finally {
+            this.info = newInfo;
         }
         return null;
     }
-    private void updateParentAfterRemove(Node<V> parent, long newPost, V newVal,
+    private void updateParentAfterRemove(AtomicInfo<V> newInfo, Node<V> parent, long newPost, V newVal,
                                          Node<V> newSub, boolean isParentHigh) {
 
         newPost = (newSub == null) ? newPost : extractPrefix(newPost, newSub.posDiff-1);
         if (parent == null) {
-            rootKey = newPost;
-            rootVal = newVal;
-            root = newSub;
+            newInfo.rootKey = newPost;
+            newInfo.rootVal = newVal;
+            newInfo.root = newSub;
         } else if (isParentHigh) {
             parent.hiPost = newPost;
             parent.hiVal = newVal;
@@ -507,7 +533,7 @@ public class CritBit64COW<V> implements Iterable<V> {
             parent.loVal = newVal;
             parent.lo = newSub;
         }
-        size--;
+        newInfo.size--;
     }
 
     public CBIterator<V> iterator() {
@@ -529,17 +555,17 @@ public class CritBit64COW<V> implements Iterable<V> {
         public CBIterator(CritBit64COW<V> cb, int DEPTH) {
             this.stack = new Node[DEPTH];
             this.readHigherNext = new byte[DEPTH];  // default = false
-
-            if (cb.size == 0) {
+            AtomicInfo<V> info = cb.info;
+            if (info.size == 0) {
                 //Tree is empty
                 return;
             }
-            if (cb.size == 1) {
-                nextValue = cb.rootVal;
-                nextKey = cb.rootKey;
+            if (info.size == 1) {
+                nextValue = info.rootVal;
+                nextKey = info.rootKey;
                 return;
             }
-            stack[++stackTop] = cb.root;
+            stack[++stackTop] = info.root;
             findNext();
         }
 
@@ -653,21 +679,21 @@ public class CritBit64COW<V> implements Iterable<V> {
             this.prefixes = new long[DEPTH];
             this.minOrig = minOrig;
             this.maxOrig = maxOrig;
-
-            if (cb.size == 0) {
+            AtomicInfo<V> info = cb.info;
+            if (info.size == 0) {
                 //Tree is empty
                 return;
             }
-            if (cb.size == 1) {
-                checkMatchFullIntoNextVal(cb.rootKey, cb.rootVal);
+            if (info.size == 1) {
+                checkMatchFullIntoNextVal(info.rootKey, info.rootVal);
                 return;
             }
-            Node<V> n = cb.root;
-            if (!checkMatch(cb.rootKey, n.posDiff)) {
+            Node<V> n = info.root;
+            if (!checkMatch(info.rootKey, n.posDiff)) {
                 return;
             }
-            stack[++stackTop] = cb.root;
-            prefixes[stackTop] = cb.rootKey;
+            stack[++stackTop] = info.root;
+            prefixes[stackTop] = info.rootKey;
             findNext();
         }
 
@@ -822,20 +848,21 @@ public class CritBit64COW<V> implements Iterable<V> {
             this.minOrig = minOrig;
             this.maxOrig = maxOrig;
 
-            if (cb.size == 0) {
+            AtomicInfo<V> info = cb.info;
+            if (info.size == 0) {
                 //Tree is empty
                 return;
             }
-            if (cb.size == 1) {
-                checkMatchFullIntoNextVal(cb.rootKey, cb.rootVal);
+            if (info.size == 1) {
+                checkMatchFullIntoNextVal(info.rootKey, info.rootVal);
                 return;
             }
-            Node<V> n = cb.root;
-            if (!checkMatch(cb.rootKey, n.posDiff)) {
+            Node<V> n = info.root;
+            if (!checkMatch(info.rootKey, n.posDiff)) {
                 return;
             }
-            stack[++stackTop] = cb.root;
-            prefixes[stackTop] = cb.rootKey;
+            stack[++stackTop] = info.root;
+            prefixes[stackTop] = info.rootKey;
             findNext();
         }
 
@@ -974,5 +1001,4 @@ public class CritBit64COW<V> implements Iterable<V> {
             return value;
         }
     }
-
 }


### PR DESCRIPTION
Updated the COW version of the CritBit to support atomic writes even when the tree has 0, 1 or 2 nodes.

This is done by keeping information like the size, root node reference and the root key/value references into a single object. This object can be updated atomically through a reference swap during the write methods.